### PR TITLE
fix: add macOS version check for base64 argument compatibility

### DIFF
--- a/scripts/install-kusion.sh
+++ b/scripts/install-kusion.sh
@@ -29,7 +29,13 @@ for arg in "$@"; do
     if [[ "$os_type" == "Linux" ]]; then
         content=$(base64 -w 0 "$path")
     elif [[ "$os_type" == "Darwin" ]]; then
-        content=$(base64 -b 0 -i "$path")
+        # Check macOS version for base64 argument compatibility
+        os_version=$(uname -r | cut -d. -f1)
+        if [[ "$os_version" -ge 25 ]]; then
+            content=$(base64 -w 0 -i "$path")
+        else
+            content=$(base64 -b 0 -i "$path")
+        fi
     else
         echo "Unsupported OS: $os_type"
         exit 1


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] Y 
- [ ] N 

    fix #126 

#### 2. What is the scope of this PR (e.g. component or file name):

`scripts/install-kusion.sh`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Other

Install script uses `base64` to encode kubeconfig key. The `base64` args changed in the latest OS X (Tahoe) 

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

`bash install-kusion.sh kubeconfig_key1=/path/to/key`

works in latest OS X

#### 6. Release note

The fix addresses compatibility issues where the base64 command parameters differ between operating systems and macOS versions. This ensures the Kusion Helm chart installation works correctly regardless of the platform.

- **Fixed base64 encoding on macOS**: Updated the install script to properly handle base64 encoding across different macOS versions
  - macOS 15+ (Darwin kernel 25+): Uses `base64 -w 0 -i`
  - Earlier macOS versions: Uses `base64 -b 0 -i`
  - Linux: Continues to use `base64 -w 0`

- **Enhanced cross-platform support**: The script now automatically detects the operating system and applies the correct base64 parameters

**Files Changed:**
- `scripts/install-kusion.sh`: Updated base64 encoding logic for cross-platform compatibility
