### PR TITLE
feat: add ingress parameter in helm chart

### DIFF
--- a/charts/karpor/templates/ingress.yaml
+++ b/charts/karpor/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: karpor-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "karpor.labels" (dict "context" . "component" "karpor-ingress") | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: karpor-server
+                port:
+                  number: {{ $.Values.server.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/karpor/values.yaml
+++ b/charts/karpor/values.yaml
@@ -165,3 +165,27 @@ job:
     repo: kusionstack/karpor
     # -- Tag for Karpor image. Defaults to the chart's appVersion if not specified.
     tag: ""
+
+# Ingress configuration
+ingress:
+  # -- Enable ingress for Karpor server.
+  enabled: true
+  # -- Ingress class name.
+  className: "nginx"
+  # -- Annotations to be added to the ingress resource.
+  annotations: 
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "off"
+  # -- TLS configuration for the ingress resource.
+  tls: []
+  # Example:
+  # tls: 
+  #   - hosts:
+  #       - karpor.example.com
+  #     secretName: karpor-tls
+  # -- Hosts configuration for the ingress resource.
+  hosts:
+    - host: karpor.example.com
+      paths:
+        - path: /
+          pathType: Prefix


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix https://github.com/KusionStack/karpor/issues/808

#### 2. What is the scope of this PR (e.g. component or file name):

charts/karpor

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

This PR addresses the request to allow automatic Ingress configuration during Helm installation. Previously, users had to manually create ingress resources after the chart was deployed. This update introduces a toggle and configuration block within values.yaml to manage Ingress resources natively through the chart.

Effects
- New Parameters: Added ingress.enabled, ingress.hosts, ingress.annotations, and ingress.tls to values.yaml. 
- Template Logic: Introduced a new ingress.yaml template that conditionally renders based on the .Values.ingress.enabled flag (default is enabled: true)
- Annotations: Default nginx based annotations for https enabled karpor-server service. If the cluster has any other ingress controller, update the values.yaml accordingly.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

No

#### 6. Release note

```release-note
Helm: Add support for automatic Ingress resource creation. You can now enable and configure Ingress directly via values.yaml using the ingress.enabled parameter.
```
